### PR TITLE
[Feat] Moya TargetType 구현, Gemini API 통신 테스트 완료

### DIFF
--- a/JjikYak.xcodeproj/project.pbxproj
+++ b/JjikYak.xcodeproj/project.pbxproj
@@ -6,6 +6,10 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		F63CA7882F3F661500C0C1F2 /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = F63CA7872F3F661500C0C1F2 /* Moya */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXFileReference section */
 		C6735BE92F3EDB060025FA25 /* JjikYak.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JjikYak.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -36,6 +40,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F63CA7882F3F661500C0C1F2 /* Moya in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -78,6 +83,7 @@
 			);
 			name = JjikYak;
 			packageProductDependencies = (
+				F63CA7872F3F661500C0C1F2 /* Moya */,
 			);
 			productName = JjikYak;
 			productReference = C6735BE92F3EDB060025FA25 /* JjikYak.app */;
@@ -107,6 +113,9 @@
 			);
 			mainGroup = C6735BE02F3EDB060025FA25;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				F63CA7862F3F661500C0C1F2 /* XCRemoteSwiftPackageReference "Moya" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = C6735BEA2F3EDB060025FA25 /* Products */;
 			projectDirPath = "";
@@ -333,6 +342,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		F63CA7862F3F661500C0C1F2 /* XCRemoteSwiftPackageReference "Moya" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Moya/Moya.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 15.0.3;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		F63CA7872F3F661500C0C1F2 /* Moya */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F63CA7862F3F661500C0C1F2 /* XCRemoteSwiftPackageReference "Moya" */;
+			productName = Moya;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = C6735BE12F3EDB060025FA25 /* Project object */;
 }

--- a/JjikYak/App/SceneDelegate.swift
+++ b/JjikYak/App/SceneDelegate.swift
@@ -18,7 +18,19 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let testVC = UIViewController()
         testVC.view.backgroundColor = .white
         
+        
+        
         print("API키 확인 : \(ConfigManager.geminiAPIKey)")
+        
+        let testService = GeminiService()
+        testService.parsePillInfo(ocrText: "타이레놀 8시간 이알 서방정") { result in
+            switch result {
+            case .success(let parsedResult):
+                print("✅ [AI 분석 성공] \n\(parsedResult)")
+            case .failure(let error):
+                print("❌ [AI 분석 실패] \(error.localizedDescription)")
+            }
+        }
         
         window.rootViewController = testVC
         

--- a/JjikYak/Data/DTO/GeminiResponse.swift
+++ b/JjikYak/Data/DTO/GeminiResponse.swift
@@ -1,7 +1,17 @@
-//
-//  Untitled.swift
-//  JjikYak
-//
-//  Created by Charlie_Kang on 2/14/26.
-//
+import Foundation
 
+struct GeminiResponse: Decodable {
+    let candidates: [Candidate]
+}
+
+struct Candidate: Decodable {
+    let content: Content
+}
+
+struct Content: Decodable {
+    let parts: [Part]
+}
+
+struct Part: Decodable {
+    let text: String
+}

--- a/JjikYak/Data/DTO/GeminiResponse.swift
+++ b/JjikYak/Data/DTO/GeminiResponse.swift
@@ -1,0 +1,7 @@
+//
+//  Untitled.swift
+//  JjikYak
+//
+//  Created by Charlie_Kang on 2/14/26.
+//
+

--- a/JjikYak/Data/Network/GeminiService.swift
+++ b/JjikYak/Data/Network/GeminiService.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Moya
+
+final class GeminiService {
+    // 1. 우리가 만든 메뉴판(GeminiTarget)을 전담할 웨이터(Provider) 생성
+    private let provider = MoyaProvider<GeminiTarget>()
+    
+    // 2. OCR로 읽은 텍스트를 던져주면, AI가 분석한 결과를 돌려주는 함수
+    func parsePillInfo(ocrText: String, completion: @escaping (Result<String, Error>) -> Void) {
+        
+        // 웨이터에게 메뉴판의 'parsePillInfo' 주문을 시킴
+        provider.request(.parsePillInfo(ocrText: ocrText)) { result in
+            switch result {
+            case .success(let response):
+                // 🚨 [디버깅용 추가] 구글이 보낸 날것(Raw)의 데이터를 문자열로 먼저 찍어서 확인
+                if let rawString = String(data: response.data, encoding: .utf8) {
+                    print("📦 [구글의 실제 답변]:\n\(rawString)")
+                }
+                
+                do {
+                    // 구글의 대답을 GeminiResponse 구조체로 변환(Decoding)
+                    let decodedData = try JSONDecoder().decode(GeminiResponse.self, from: response.data)
+                    
+                    // 결과 텍스트만 쏙 빼서 전달
+                    if let resultText = decodedData.candidates.first?.content.parts.first?.text {
+                        completion(.success(resultText))
+                    } else {
+                        let error = NSError(domain: "GeminiError", code: -1, userInfo: [NSLocalizedDescriptionKey: "응답 텍스트가 비어있습니다."])
+                        completion(.failure(error))
+                    }
+                } catch {
+                    // 🚨 [디버깅용 추가] 디코딩이 왜 실패했는지 상세 이유를 확인
+                    print("💥 [디코딩 실패 상세 이유]: \(error)")
+                    completion(.failure(error))
+                }
+                
+            case .failure(let error):
+                // 인터넷이 끊겼거나 통신 자체가 실패했을 때 에러 전달
+                completion(.failure(error))
+            }
+        }
+    }
+}

--- a/JjikYak/Data/Network/GeminiTarget.swift
+++ b/JjikYak/Data/Network/GeminiTarget.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Moya
+
+enum GeminiTarget {
+    case parsePillInfo(ocrText: String)
+}
+
+extension GeminiTarget: TargetType {
+    
+    var baseURL: URL {
+        return URL(string: "https://generativelanguage.googleapis.com/v1beta/models")!
+    }
+    
+    // gemini 2.5 flash 버전을 사용함
+    var path: String {
+        switch self {
+        case .parsePillInfo:
+            return "/gemini-2.5-flash:generateContent"
+        }
+    }
+    
+    // 통신 방식 (Method) - 데이터 전송 및 결과 받기(POST)
+    var method: Moya.Method {
+        return .post
+    }
+    
+    // 헤더 (Headers) -API Key를 꺼내오는 핵심 구간
+    var headers: [String: String]? {
+        return [
+            "Content-Type": "application/json",
+            "x-goog-api-key": ConfigManager.geminiAPIKey
+        ]
+    }
+    
+    // 파라미터 & 바디 (Task) 실제 보낼 내용물
+    var task: Task {
+        switch self {
+        case .parsePillInfo(let ocrText):
+            // Gemini API가 요구하는 복잡한 JSON 형식을 딕셔너리로 미리 구성.
+            let parameters: [String: Any] = [
+                "contents": [[
+                    "parts": [[
+                        // 프롬프트 엔지니어링으로 AI에게 명령하는 부분, 답변이 마음에 안들면 여기서 수정
+                        "text": "다음은 약 봉투를 OCR로 읽은 텍스트야. 약 이름, 복용법, 효능을 JSON 형식으로 추출해줘. 만약 텍스트에 복용법이 안적혀 있다면 너가 아는 의학 지식으로 추천 복용법을 알려주고, 효능이 안 적혀 있다면, 네가 아는 의학 지식을 바탕으로 해당 약의 일반적인 효능을 채워 넣어줘: \(ocrText)"
+                    ]]
+                ]]
+            ]
+            // 위 딕셔너리를 JSON 바디로 변환해서 보냄
+            return .requestParameters(parameters: parameters, encoding: JSONEncoding.default)
+        }
+        
+        
+    }
+}

--- a/JjikYak/Global/Utils/ConfigManager.swift
+++ b/JjikYak/Global/Utils/ConfigManager.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+//API Key를 편리하게 가져오기 위한 파일
 struct ConfigManager {
     static var geminiAPIKey: String {
         guard let path = Bundle.main.path(forResource: "Secrets", ofType: "plist"),


### PR DESCRIPTION
## 📌 작업 요약 #7 
- OCR 텍스트 분석을 위해, Google Gemini API(2.5-flash)와 통신하는 Moya 기반의 네트워크 뼈대를 구축하고 API Key 보안 세팅을 완료

---

## 🛠 주요 변경 사항
- SPM을 통해 `Moya` 네트워크 라이브러리 추가
- **API 명세서(`GeminiTarget`):**  `TargetType`을 채택하여 Gemini 2.5 모델 세팅(처음에 1.5로 설정했다가 에러나서, 2.5로 변경했음 모델 변경되어 서비스 종료되는지도 팔로업 해야 할 듯!)
- **네트워크 서비스(`GeminiService` & DTO):**  `GeminiResponse` DTO를 생성하여 구글 서버의 복잡한 JSON 응답 매핑
  - `MoyaProvider`를 활용해 실제 통신을 수행하고, 알맹이 텍스트만 `Result` 타입으로 반환하는 로직 구현
- **보안 세팅:** `ConfigManager`를 활용하여 `x-goog-api-key` 헤더에 로컬 API Key 안전하게 주입

---

## 📷 실행 화면 (선택)
<img width="668" height="88" alt="스크린샷 2026-02-14 오전 1 01 24" src="https://github.com/user-attachments/assets/bc5366db-ab17-4bc3-818b-aead18d6433c" />

---

## 🚨 리뷰 포인트

- ScenDelegate에 테스트용 코드를 작성했으니(현재는 타이레놀) 해당 코드에 다른 약을 추가하고 실행하면 프린트문으로 확인가능

---

## ☑️ 체크리스트
- [x] 빌드 성공
- [x] 기능 정상 동작 (콘솔 통신 테스트 완료)
- [x] 기존 기능 영향 없음
- [x] 컨벤션 준수