### PR TITLE
[Feat] 코어데이터 엔티티 정의 및 CRUD 로직 구현

### DIFF
--- a/JjikYak/App/AppDelegate.swift
+++ b/JjikYak/App/AppDelegate.swift
@@ -30,50 +30,5 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
 
-    // MARK: - Core Data stack
-
-    lazy var persistentContainer: NSPersistentContainer = {
-        /*
-         The persistent container for the application. This implementation
-         creates and returns a container, having loaded the store for the
-         application to it. This property is optional since there are legitimate
-         error conditions that could cause the creation of the store to fail.
-        */
-        let container = NSPersistentContainer(name: "JjikYak")
-        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
-            if let error = error as NSError? {
-                // Replace this implementation with code to handle the error appropriately.
-                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-                 
-                /*
-                 Typical reasons for an error here include:
-                 * The parent directory does not exist, cannot be created, or disallows writing.
-                 * The persistent store is not accessible, due to permissions or data protection when the device is locked.
-                 * The device is out of space.
-                 * The store could not be migrated to the current model version.
-                 Check the error message to determine what the actual problem was.
-                 */
-                fatalError("Unresolved error \(error), \(error.userInfo)")
-            }
-        })
-        return container
-    }()
-
-    // MARK: - Core Data Saving support
-
-    func saveContext () {
-        let context = persistentContainer.viewContext
-        if context.hasChanges {
-            do {
-                try context.save()
-            } catch {
-                // Replace this implementation with code to handle the error appropriately.
-                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-                let nserror = error as NSError
-                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
-            }
-        }
-    }
-
 }
 

--- a/JjikYak/App/SceneDelegate.swift
+++ b/JjikYak/App/SceneDelegate.swift
@@ -12,6 +12,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        
         guard let windowScene = (scene as? UIWindowScene) else { return }
         let window = UIWindow(windowScene: windowScene)
         
@@ -54,7 +55,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // to restore the scene back to its current state.
 
         // Save changes in the application's managed object context when the application transitions to the background.
-        (UIApplication.shared.delegate as? AppDelegate)?.saveContext()
+        CoreDataManager.shared.saveContext()
     }
 
 

--- a/JjikYak/Data/LocalDB/CoreDataManager.swift
+++ b/JjikYak/Data/LocalDB/CoreDataManager.swift
@@ -3,7 +3,7 @@ import UIKit
 
 final class CoreDataManager {
     
-    static let shard = CoreDataManager()
+    static let shared = CoreDataManager()
     private init() {}
     
     lazy var persistentContainer: NSPersistentContainer = {
@@ -21,6 +21,7 @@ final class CoreDataManager {
         return persistentContainer.viewContext
     }
     
+    // MARK: - CREATE (저장)
     // 저장
     func saveContext() {
         let context = persistentContainer.viewContext
@@ -33,7 +34,9 @@ final class CoreDataManager {
             }
         }
     }
-        
+    
+    // MARK: - READ (불러오기)
+    // 모든 약 불러오기
     func fetchAllPills() -> [Pill] {
         let request: NSFetchRequest<Pill> = Pill.fetchRequest()
         let sort = NSSortDescriptor(key: "alarmTime", ascending: true)
@@ -41,4 +44,42 @@ final class CoreDataManager {
         
         return(try? context.fetch(request)) ?? []
     }
+    // 특정 날짜 약만 불러오기
+    func fetchPills(on date: Date) -> [Pill] {
+        let request: NSFetchRequest<Pill> = Pill.fetchRequest()
+        
+        // 날짜 범위 설정 (00:00:00 ~ 23:59:59)
+        let calendar = Calendar.current
+        let startDate = calendar.startOfDay(for: date)
+        guard let endDate = calendar.date(byAdding: .day, value: 1, to: startDate) else { return [] }
+        
+        // 조건(Predicate): 알림 시간이 오늘 하루 안에 있는 것들
+        let predicate = NSPredicate(format: "alarmTime >= %@ AND alarmTime < %@", startDate as NSDate, endDate as NSDate)
+        
+        request.predicate = predicate
+        // 아침-> 점심-> 저녁 순
+        request.sortDescriptors = [NSSortDescriptor(key: "alarmTime", ascending: true)]
+        
+        do {
+            return try context.fetch(request)
+        } catch {
+            print("❌ 날짜별 데이터 로드 실패: \(error)")
+            return []
+        }
+    }
+    
+    // MARK: - UPDATE (수정)
+    // 약 복용 완료(Check) 상태 변경
+    func updatePillStatus(pill: Pill, isTaken: Bool) {
+        pill.isTaken = isTaken
+        saveContext()
+    }
+    
+    // MARK: - DELETE (삭제)
+    //삭제
+    func deletePill(_ pill: Pill) {
+        context.delete(pill)
+        saveContext()
+    }
+    
 }

--- a/JjikYak/Data/LocalDB/CoreDataManager.swift
+++ b/JjikYak/Data/LocalDB/CoreDataManager.swift
@@ -1,0 +1,44 @@
+import CoreData
+import UIKit
+
+final class CoreDataManager {
+    
+    static let shard = CoreDataManager()
+    private init() {}
+    
+    lazy var persistentContainer: NSPersistentContainer = {
+        let container = NSPersistentContainer(name: "JjikYak")
+        container.loadPersistentStores(completionHandler: {
+            (storeDescription, error) in
+            if let error = error as NSError? {
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        })
+        return container
+    }()
+    
+    var context: NSManagedObjectContext {
+        return persistentContainer.viewContext
+    }
+    
+    // 저장
+    func saveContext() {
+        let context = persistentContainer.viewContext
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                let nserror = error as NSError
+                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
+            }
+        }
+    }
+        
+    func fetchAllPills() -> [Pill] {
+        let request: NSFetchRequest<Pill> = Pill.fetchRequest()
+        let sort = NSSortDescriptor(key: "alarmTime", ascending: true)
+        request.sortDescriptors = [sort]
+        
+        return(try? context.fetch(request)) ?? []
+    }
+}

--- a/JjikYak/Data/LocalDB/JjikYak.xcdatamodeld/JjikYak.xcdatamodel/contents
+++ b/JjikYak/Data/LocalDB/JjikYak.xcdatamodeld/JjikYak.xcdatamodel/contents
@@ -1,4 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="1" systemVersion="11A491" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="false" userDefinedModelVersionIdentifier="">
-    <elements/>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="23G93" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Pill" representedClassName="Pill" syncable="YES" codeGenerationType="class">
+        <attribute name="alarmTime" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dosage" optional="YES" attributeType="String"/>
+        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="imagePath" optional="YES" attributeType="String"/>
+        <attribute name="isTaken" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="memo" optional="YES" attributeType="String"/>
+        <attribute name="title" attributeType="String"/>
+    </entity>
 </model>


### PR DESCRIPTION
## 📌 작업 요약
- 약 정보를 로컬에 저장하기 위해 코어데이터 초기 세팅 및 데이터 관리하는 Manager 클래스를 구현

---

## 🛠 주요 변경 사항
- **CoreData 모델링 (`JjikYak.xcdatamodeld`)**
  - `Pill` 엔티티 생성 및 속성 정의 (`id`, `title`, `dosage`, `alarmTime`, `isTaken`, `imagePath` 등)
  - 필수 데이터와 선택 데이터(Optional) 구분 및 타입 설정 완료.

- **`CoreDataManager.swift` 구현**
  - 싱글톤 패턴(`shared`)을 사용하여 앱 전역에서 접근 가능하도록 설정.
  - **CRUD 메서드 구현:**
    - `saveContext()`: 컨텍스트 변경 사항 저장.
    - `fetchAllPills()`: 모든 약 불러오기.
    - `fetchPills(on date:)`: `NSPredicate`를 사용하여 특정 날짜(00:00 ~ 23:59)의 약만 필터링 조회.
    - `updatePillStatus()`: 약 복용 여부(Check) 업데이트.
    - `deletePill()`: 약 삭제 기능.

- **앱 생명주기 연동 (`SceneDelegate.swift`)**
  - 앱이 백그라운드로 내려갈 때(`sceneDidEnterBackground`) 변경 사항이 자동 저장되도록 설정.
  - `AppDelegate`의 불필요한 CoreData 코드를 제거하고 Manager로 이관.

---

## 🚨 리뷰 포인트
- 엔티티 속성: Pill 엔티티의 속성 타입들이 적절한지 확인해 주세요. (이미지는 DB 용량을 위해 Binary Data가 아닌 String(경로)으로 저장하도록 설계했습니다.)
- 싱글톤 사용: CoreDataManager.shared로 접근하는 구조입니다.

---

## ☑️ 체크리스트
- [x] 빌드 성공
- [x] 기능 정상 동작
- [x] 기존 기능 영향 없음
- [x] 컨벤션 준수

