### PR TITLE
[Feat] 디코딩된 배열 데이터를 UI에 바인딩 작업

### DIFF
--- a/JjikYak/App/SceneDelegate.swift
+++ b/JjikYak/App/SceneDelegate.swift
@@ -44,6 +44,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                     // 단일 PillInfo 객체를 배열에 감싸서 화면에 전달
                     resultVC.pillList = pillInfos
                     
+                    resultVC.bindData()
+                    
                     window.rootViewController = resultVC
                     
                 case .failure(let error):

--- a/JjikYak/Scene/ScanResult/ScanResultVC.swift
+++ b/JjikYak/Scene/ScanResult/ScanResultVC.swift
@@ -182,11 +182,14 @@ final class ScanResultViewController: UIViewController {
             return cardView
         }
     
-    private func bindData() {
-            // 1. 파란색 안내 박스 텍스트 업데이트
+        func bindData() {
+            // 1. 기존에 그려진 카드가 있다면 싹 다 지우기 (중복 방지 초기화)
+            pillListStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+            
+            // 2. 파란색 안내 박스 텍스트 업데이트
             summaryLabel.text = "총 \(pillList.count)개의 약이 인식되었습니다"
             
-            // 2. 바구니에 있는 약 개수만큼 카드 찍어내기
+            // 3. 바구니에 있는 약 개수만큼 카드 찍어내기
             for pill in pillList {
                 let card = createPillCard(name: pill.pillName, dosage: pill.dosage, efficacy: pill.efficacy)
                 pillListStackView.addArrangedSubview(card)


### PR DESCRIPTION
## 📌 작업 요약 #19 
- Gemini API 통신을 통해 디코딩된 `[PillInfo]` 배열 데이터를 스캔 결과 화면(`ScanResultViewController`)의 UI에 바인딩

---

## 🛠 주요 변경 사항
- **동적 UI 렌더링 로직 추가 (`ScanResultViewController`)**
  - 전달받은 `pillList` 배열의 개수만큼 `createPillCard`를 호출하여 약 정보(이름, 복용법, 효능)를 담은 카드를 동적으로 생성하고 렌더링함.
  - 상단 안내 박스(`summaryLabel`)에 총 인식된 약의 개수가 맞춤형으로 표시되도록 연동함.
- **뷰 중복 생성 방지 (방어 로직)**
  - `bindData()` 호출 시 스택뷰 내부에 기존 카드가 남아있을 경우를 대비해, `removeFromSuperview()`를 활용한 뷰 초기화 로직 구현.
- **데이터 플로우 테스트 (`SceneDelegate`)**
  - 임시 통신 코드를 통해 `pillList`에 데이터를 주입하고 `bindData()`를 호출하여 전체 흐름(Data -> UI) 정상 동작 확인.

---

## 📷 실행 화면
<img width="230" height="470" alt="simulator_screenshot_DC7168D9-70AA-4164-B3F3-6C5511531D64" src="https://github.com/user-attachments/assets/e189c384-e6eb-4a2a-ad6c-ab40d571b41d" />


---

## ☑️ 체크리스트
- [x] 시뮬레이터 빌드 및 UI 렌더링 성공
- [x] 데이터 개수에 따른 스크롤뷰 동적 레이아웃 확인
- [x] 컨벤션 준수