### PR TITLE
[Feat] 처방 정보 상세 설정 화면(Wizard UI) 및 페이징 로직 구현 

### DIFF
--- a/JjikYak/Presentation/AddPill/AddPillDetailViewController.swift
+++ b/JjikYak/Presentation/AddPill/AddPillDetailViewController.swift
@@ -1,0 +1,209 @@
+//
+//  AddPillDetailViewController.swift
+//  JjikYak
+//
+//
+
+import UIKit
+import SnapKit
+import RxSwift
+import RxCocoa
+
+class AddPillDetailViewController: UIViewController {
+    
+    private let disposeBag = DisposeBag()
+    
+    // MARK: - 핵심 데이터 (상태 관리)
+    private var pillList: [PillInfo]
+    private var currentIndex: Int = 0 // 현재 보고 있는 약의 인덱스
+    
+    // MARK: - UI Components (상단 고정 영역)
+    private let topContainerView = UIView()
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "처방 정보 확인"
+        label.font = .systemFont(ofSize: 20, weight: .bold)
+        label.textColor = .black
+        return label
+    }()
+    
+    private let progressLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 14, weight: .medium)
+        label.textColor = .systemBlue
+        return label
+    }()
+    
+    private let progressBar: UIProgressView = {
+        let progress = UIProgressView(progressViewStyle: .default)
+        progress.progressTintColor = .systemBlue
+        progress.trackTintColor = UIColor.systemGray5
+        progress.layer.cornerRadius = 2
+        progress.clipsToBounds = true
+        return progress
+    }()
+    
+    // MARK: - UI Components (스크롤 영역)
+    private let scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.showsVerticalScrollIndicator = false
+        return scrollView
+    }()
+    
+    // 이 스택뷰 안에 효능, 주의사항, 시간 설정 카드들이 차곡차곡 들어갈 예정입니다!
+    private let contentStackView: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.spacing = 16
+        return stack
+    }()
+    
+    private let pillNameLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 24, weight: .heavy)
+        label.textColor = .systemBlue
+        label.numberOfLines = 0
+        return label
+    }()
+    
+    // MARK: - UI Components (하단 고정 버튼)
+    private let nextButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("다음 >", for: .normal)
+        button.setTitleColor(.white, for: .normal)
+        button.backgroundColor = .systemBlue
+        button.titleLabel?.font = .systemFont(ofSize: 18, weight: .bold)
+        button.layer.cornerRadius = 12
+        return button
+    }()
+    
+    // MARK: - Initialization
+    init(pillList: [PillInfo]) {
+        self.pillList = pillList
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Lifecycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        setupConstraints()
+        
+        // 화면이 켜지면 첫 번째(0번) 약 데이터를 화면에 뿌려줍니다!
+        updateUIForCurrentIndex()
+        bindAction()
+    }
+    
+    // MARK: - Setup
+    private func setupUI() {
+        view.backgroundColor = .systemBackground
+        
+        view.addSubview(topContainerView)
+        topContainerView.addSubview(titleLabel)
+        topContainerView.addSubview(progressLabel)
+        topContainerView.addSubview(progressBar)
+        
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentStackView)
+        
+        // 스택뷰에 약 이름 라벨 추가 (나머지 카드들은 다음 스텝에서 여기에 추가됩니다!)
+        contentStackView.addArrangedSubview(pillNameLabel)
+        
+        view.addSubview(nextButton)
+    }
+    
+    private func setupConstraints() {
+        topContainerView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(80)
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(16)
+            $0.centerX.equalToSuperview()
+        }
+        
+        progressLabel.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(8)
+            $0.centerX.equalToSuperview()
+        }
+        
+        progressBar.snp.makeConstraints {
+            $0.top.equalTo(progressLabel.snp.bottom).offset(12)
+            $0.leading.trailing.equalToSuperview().inset(24)
+            $0.height.equalTo(4)
+        }
+        
+        // 스크롤 뷰는 상단 바와 하단 버튼 사이에 꽉 차게!
+        scrollView.snp.makeConstraints {
+            $0.top.equalTo(topContainerView.snp.bottom)
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(nextButton.snp.top).offset(-16)
+        }
+        
+        contentStackView.snp.makeConstraints {
+            $0.edges.equalToSuperview().inset(24)
+            $0.width.equalToSuperview().offset(-48) // 좌우 여백 24씩 뺌
+        }
+        
+        nextButton.snp.makeConstraints {
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-16)
+            $0.leading.trailing.equalToSuperview().inset(24)
+            $0.height.equalTo(56)
+        }
+    }
+    
+    // MARK: - Core Logic: 화면 갈아끼우기
+    private func updateUIForCurrentIndex() {
+        // 방어 로직: 인덱스가 배열 크기를 넘어가면 크래시 나므로 막아줌
+        guard currentIndex < pillList.count else { return }
+        
+        let currentPill = pillList[currentIndex]
+        
+        // 1. 상단 프로그레스 텍스트 & 바 업데이트
+        progressLabel.text = "\(currentIndex + 1) / \(pillList.count) 번째 약"
+        let progressRatio = Float(currentIndex + 1) / Float(pillList.count)
+        progressBar.setProgress(progressRatio, animated: true)
+        
+        // 2. 약 이름 업데이트
+        // (훈님의 PillInfo 구조체 변수명에 맞게 currentPill.name 또는 currentPill.pillName 으로 변경해주세요!)
+        pillNameLabel.text = currentPill.pillName
+        
+        // 3. 버튼 텍스트 업데이트 (마지막 약이면 '저장하기'로 변경!)
+        if currentIndex == pillList.count - 1 {
+            nextButton.setTitle("저장하기", for: .normal)
+            nextButton.backgroundColor = .systemGreen
+        } else {
+            nextButton.setTitle("다음 >", for: .normal)
+            nextButton.backgroundColor = .systemBlue
+        }
+    }
+    
+    // MARK: - Action Binding
+    private func bindAction() {
+        nextButton.rx.tap
+            .subscribe(onNext: { [weak self] in
+                guard let self = self else { return }
+                
+                if self.currentIndex < self.pillList.count - 1 {
+                    // 💡 아직 다음 약이 남아있다면? -> 인덱스를 올리고 화면 갱신!
+                    self.currentIndex += 1
+                    UIView.animate(withDuration: 0.3) {
+                        self.updateUIForCurrentIndex()
+                        self.view.layoutIfNeeded()
+                    }
+                } else {
+                    // 💡 마지막 약까지 다 확인했다면? -> 서버에 전송하고 뷰 닫기!
+                    print("✅ 최종 데이터 저장 로직 실행: \(self.pillList)")
+                    self.dismiss(animated: true)
+                }
+            })
+            .disposed(by: disposeBag)
+    }
+}

--- a/JjikYak/Presentation/AddPill/AddPillViewController.swift
+++ b/JjikYak/Presentation/AddPill/AddPillViewController.swift
@@ -174,7 +174,7 @@ extension AddPillViewController: UIImagePickerControllerDelegate, UINavigationCo
             let recognizedStrings = observations.compactMap { $0.topCandidates(1).first?.string }
             var fullText = recognizedStrings.joined(separator: "\n")
             
-            // 🔒 [보안] 개인정보 마스킹
+            // [보안] 개인정보 마스킹
             let rrnPattern = "\\d{6}[- ]?\\d{7}"
             let phonePattern = "010[- ]?\\d{4}[- ]?\\d{4}"
             
@@ -196,10 +196,18 @@ extension AddPillViewController: UIImagePickerControllerDelegate, UINavigationCo
                         
                         // 1. 결과 화면 뷰 컨트롤러 생성 (데이터 넘겨주기)
                         let resultVC = ScanResultViewController(pillList: pillInfos)
-                        
-                        // 2. 화면 전환
-                        //                            self.navigationController?.pushViewController(resultVC, animated: true)
-                         self?.present(resultVC, animated: true)
+                        // 2. 맞아요 신호가 오면 실행될 코드
+                        resultVC.onConfirm = { [weak self] confirmedPills in
+                            print("약 확인 완료! 상세 설정 화면(Wizard)으로 이동합니다!")
+                            
+                            // 상세 설정 화면 뼈대를 생성하고 데이터를 넘겨줌
+                            let detailVC = AddPillDetailViewController(pillList: confirmedPills)
+                            detailVC.modalPresentationStyle = .fullScreen // 꽉 찬 화면으로 띄우기
+                            
+                            // 화면 전환
+                            self?.present(detailVC, animated: true)
+                        }
+                        self?.present(resultVC, animated: true)
                     case .failure(let error):
                         print("AI 분석 실패: \(error.localizedDescription)")
                     }

--- a/JjikYak/Presentation/ScanResult/ScanResultVC.swift
+++ b/JjikYak/Presentation/ScanResult/ScanResultVC.swift
@@ -8,6 +8,7 @@ class ScanResultViewController: UIViewController {
     private let disposeBag = DisposeBag()
     
     var pillList: [PillInfo] = []
+    var onConfirm: (([PillInfo]) -> Void)?
     
     // 뒷배경을 어둡게 만들어줄 투명 뷰
     private let dimView: UIView = {
@@ -198,7 +199,7 @@ class ScanResultViewController: UIViewController {
         }
     }
     
-    // 디자인 시안에 맞춘 개별 약 행(Row) 생성
+    // 개별 약 행(Row) 생성
     private func createPillRowView(index: Int, name: String) -> UIView {
         let view = UIView()
         view.layer.cornerRadius = 16
@@ -253,7 +254,12 @@ class ScanResultViewController: UIViewController {
         
         correctButton.rx.tap
             .subscribe(onNext: { [weak self] in
-                print("✅ 맞아요 클릭 - 다음 플로우로 진행 (구현 예정)")
+                            guard let self = self else { return }
+                            
+                            // 2. 팝업을 닫으면서(dismiss), 다음 화면으로 가라고 신호(onConfirm)를 보냅니다!
+                            self.dismiss(animated: true) {
+                                self.onConfirm?(self.pillList)
+                            }
             })
             .disposed(by: disposeBag)
     }


### PR DESCRIPTION
## 📌 작업 요약
- 스캔 결과 확인 팝업에서 이어지는 '처방 정보 상세 설정 화면(Wizard UI)'의 기본 뼈대 구축 (#33)
- 팝업창의 `onConfirm` 클로저를 수신하여 상세 설정 화면으로 넘어가는 네비게이션(화면 전환) 연동
- 하나의 View Controller에서 여러 개의 약 데이터를 관리하는 상태(`currentIndex`) 로직 1차 구현

---

## 🛠 주요 변경 사항
- **`AddPillDetailViewController` 뷰 생성 및 레이아웃 구현**
  - 상단 고정 영역: 타이틀 및 진행도(`UIProgressView`) 프로그레스 바 구현
  - 중앙 영역: 약 상세 카드가 들어갈 `UIScrollView` 및 `UIStackView` 뼈대 배치
  - 하단 영역: 약 순서에 따라 텍스트/색상이 변경되는 상태 기반 `[다음 >]` / `[저장하기]` 버튼 구현
- **화면 전환 로직 연결**
  - `AddPillViewController` 내부에서 `ScanResultViewController`의 `onConfirm` 클로저 이벤트 수신
  - 전달받은 `[PillInfo]` 데이터를 주입하며 `AddPillDetailViewController`를 FullScreen 모달로 띄우기 (Present)
- **페이징(Paging) 코어 로직 1차 구현**
  - `currentIndex` 상태값을 두어, 하단 버튼 클릭 시 뷰를 새로 띄우지 않고 내부 텍스트 및 프로그레스 바만 동적으로 갱신(`Reload`)하도록 설계

---

## 📷 실행 화면 (선택)

---

## 🚨 리뷰 포인트
- 여러 개의 약 화면을 각기 다른 뷰 컨트롤러로 만들지 않고, **하나의 뷰 안에서 `currentIndex` 변수를 활용해 데이터만 갈아 끼우는(State Management) 방식**으로 설계.
- 스크롤 뷰 안의 `contentStackView`는 현재 비어있으며(약 이름표만 존재), 다음 PR에서 이 스택뷰 내부에 효능, 주의사항, 복용 시간 설정 등 세부 컴포넌트들을 추가해 나갈 예정.

---

## ☑️ 체크리스트
- [x] 빌드 성공
- [x] 기능 정상 동작 (맞아요 클릭 시 새 화면 노출 및 다음 버튼 클릭 시 프로그레스 바 작동)
- [x] 기존 기능 영향 없음
- [x] 컨벤션 준수

---
Closes #33 