### PR TITLE
[Fix] 중복 알림 이슈 해결

### DIFF
--- a/JjikYak/Global/Utils/NotificationManager.swift
+++ b/JjikYak/Global/Utils/NotificationManager.swift
@@ -39,13 +39,13 @@ class NotificationManager {
             content.body = "[\(title)] 드실 시간이에요! 잊지 말고 챙겨 드세요."
             content.sound = .default
             
-            // 매일 해당 시간에 울리도록 설정
+            //연, 월, 일, 시간, 분을 모두 추출하고 반복(repeats)을 false로 설정합니다.
             let calendar = Calendar.current
-            let components = calendar.dateComponents([.hour, .minute], from: time)
-            let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: true)
+            let components = calendar.dateComponents([.year, .month, .day, .hour, .minute], from: time)
+            let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: false)
             
-            // 알림 고유 ID (나중에 개별 삭제할 때를 대비해 Pill의 ID나 이름을 사용)
-            let request = UNNotificationRequest(identifier: "PillNotification_\(title)", content: content, trigger: trigger)
+            // 알림 고유 ID
+            let request = UNNotificationRequest(identifier: "PillNotification_\(pill.id?.uuidString ?? title)", content: content, trigger: trigger)
             
             center.add(request) { error in
                 if let error = error {


### PR DESCRIPTION
## 📌 작업 요약
- 코어데이터(CoreData)에 저장된 약 복용 날짜 및 시간에 맞춰 푸시 알림이 정확하게 울리도록 알림 스케줄링 로직을 수정했습니다.

---

## 🛠 주요 변경 사항
- **알림 트리거(Trigger) 조건 수정**: 
  - 기존 시간/분(`[.hour, .minute]`) 기반의 매일 반복 알림(`repeats: true`)으로 인해 다른 날짜의 알림이 오늘 울리던 버그를 수정했습니다.
  - 연, 월, 일, 시, 분을 모두 추출하여 **지정된 날짜와 시간에 딱 한 번만 울리도록(`repeats: false`)** 변경했습니다.
- **고유 Identifier 적용 (알림 누락 방지)**:
  - 알림 등록 시 식별자를 약 이름(`title`)에서 코어데이터의 고유 식별자(`pill.id?.uuidString`)로 변경했습니다.
  - 이를 통해 같은 이름의 약(예: 타이레놀)을 하루에 여러 번 복용하도록 추가하더라도 알림이 덮어씌워지거나 누락되지 않고 개별적으로 안전하게 등록됩니다.

---

## 📷 실행 화면 (선택)
---

## 🚨 리뷰 포인트
- `NotificationManager`의 `scheduleNotifications` 함수 내부 `UNCalendarNotificationTrigger` 로직 변경 사항을 확인 부탁드립니다.
- 코어데이터의 `pill.id`를 활용한 알림 식별자(Identifier) 부여 방식이 적절한지 검토해 주세요.

---

## ☑️ 체크리스트
- [x] 빌드 성공
- [x] 기능 정상 동작 (지정된 날짜/시간에 알림 정상 수신 확인)
- [x] 기존 기능 영향 없음
- [x] 컨벤션 준수